### PR TITLE
Refine version2 timer display

### DIFF
--- a/version2/index.html
+++ b/version2/index.html
@@ -45,13 +45,6 @@
     body.dark-mode .radial-progress {
       background: conic-gradient(var(--ring-color-dark) calc(var(--value) * 1%), #444 0);
     }
-    .action-bar {
-      position: fixed;
-      bottom: 1rem;
-      left: 0;
-      right: 0;
-      padding: 0 1rem;
-    }
     .secondary-links {
       position: absolute;
       top: 0;
@@ -61,7 +54,7 @@
       display: flex;
       justify-content: space-between;
     }
-    .preset {
+    .adjust-time {
       margin-right: .25rem;
       margin-bottom: .25rem;
     }
@@ -74,6 +67,7 @@
   </div>
   <div class="container text-center pt-5" id="homeScreen">
     <h1 id="endTimeDisplay">Ends · --:--</h1>
+    <div id="timeInfo" class="text-muted mb-3"></div>
     <div class="my-3 d-flex justify-content-center">
       <div id="progressRing" class="radial-progress" data-label="0%"></div>
     </div>
@@ -99,23 +93,22 @@
             <div class="input-group-prepend">
               <button type="button" id="prodMinus" class="btn btn-outline-secondary">-</button>
             </div>
-            <input type="range" id="productivitySlider" class="form-control" min="50" max="150" step="5" value="100">
+            <input type="range" id="productivitySlider" class="form-control" min="50" max="100" step="5" value="100">
             <div class="input-group-append">
               <button type="button" id="prodPlus" class="btn btn-outline-secondary">+</button>
             </div>
           </div>
         </div>
-        <div class="mb-2">
-          <button type="button" class="btn btn-sm btn-outline-primary preset" data-minutes="25">25 min</button>
-          <button type="button" class="btn btn-sm btn-outline-primary preset" data-minutes="45">45 min</button>
-          <button type="button" class="btn btn-sm btn-outline-primary preset" data-minutes="60">1 h</button>
-          <button type="button" class="btn btn-sm btn-outline-primary preset" data-minutes="120">2 h</button>
+        <div class="mb-2 d-flex flex-wrap justify-content-center">
+          <button type="button" class="btn btn-sm btn-outline-primary adjust-time m-1" data-minutes="15">+15m</button>
+          <button type="button" class="btn btn-sm btn-outline-primary adjust-time m-1" data-minutes="-15">-15m</button>
+          <button type="button" class="btn btn-sm btn-outline-primary adjust-time m-1" data-minutes="60">+1h</button>
+          <button type="button" class="btn btn-sm btn-outline-primary adjust-time m-1" data-minutes="-60">-1h</button>
+          <button type="button" class="btn btn-sm btn-outline-primary adjust-time m-1" data-minutes="240">+4h</button>
+          <button type="button" class="btn btn-sm btn-outline-primary adjust-time m-1" data-minutes="-240">-4h</button>
         </div>
       </div>
     </div>
-  </div>
-  <div class="action-bar">
-    <button id="startStopBtn" class="btn btn-success btn-block">Start</button>
   </div>
 
   <!-- Settings Modal -->


### PR DESCRIPTION
## Summary
- revamp v2 HTML layout to drop start/stop UI
- show remaining time and progress percentage under end time
- cap productivity slider at 100% and adjust slider buttons
- replace old presets with +/- time adjust buttons
- simplify JS logic so timer runs automatically and updates the new info section

## Testing
- `node -c version2/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68403987ae88833097dddf32c81338d3