### PR TITLE
Fullscreen progress background

### DIFF
--- a/version2/index.html
+++ b/version2/index.html
@@ -28,24 +28,23 @@
       font-weight: bold;
     }
     .radial-progress {
-      --size: 180px;
-      --thickness: 12px;
+      --size: 200vmax;
       --value: 0;
+      position: fixed;
+      top: 50%;
+      left: 50%;
       width: var(--size);
       height: var(--size);
+      transform: translate(-50%, -50%);
       border-radius: 50%;
-      position: relative;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: conic-gradient(var(--ring-color) calc(var(--value) * 1%), #e5e7eb 0);
+      background: conic-gradient(var(--ring-color) calc(var(--value) * 1%), var(--bg-light) 0);
+      z-index: -1;
     }
     .radial-progress::after {
-      content: attr(data-label);
-      font-size: 1.25rem;
+      content: '';
     }
     body.dark-mode .radial-progress {
-      background: conic-gradient(var(--ring-color-dark) calc(var(--value) * 1%), #444 0);
+      background: conic-gradient(var(--ring-color-dark) calc(var(--value) * 1%), var(--bg-dark) 0);
     }
     .secondary-links {
       position: absolute;
@@ -67,12 +66,10 @@
     <button id="historyBtn" class="btn btn-link p-0" aria-label="History"><i class="fas fa-clock"></i></button>
     <button id="settingsBtn" class="btn btn-link p-0" aria-label="Settings" data-toggle="modal" data-target="#settingsModal"><i class="fas fa-cog"></i></button>
   </div>
+  <div id="progressRing" class="radial-progress" aria-hidden="true"></div>
   <div class="container text-center pt-5" id="homeScreen">
     <h1 id="endTimeDisplay">Ends · --:--</h1>
     <div id="timeInfo" class="text-muted mb-3"></div>
-      <div class="my-3 d-flex justify-content-center">
-        <div id="progressRing" class="radial-progress"></div>
-      </div>
     <div class="card input-card text-left mx-auto" style="max-width: 350px;">
       <div class="card-body">
         <div class="form-group">
@@ -82,7 +79,7 @@
         <div class="form-row">
           <div class="col">
             <label for="durationHours">Hours</label>
-            <input id="durationHours" type="number" min="0" max="23" value="0" class="form-control">
+            <input id="durationHours" type="number" min="0" max="23" value="7" class="form-control">
           </div>
           <div class="col">
             <label for="durationMinutes">Minutes</label>

--- a/version2/script.js
+++ b/version2/script.js
@@ -25,6 +25,8 @@ let endTimestamp;
 
 function setStartDefault() {
   startTime.value = '07:00';
+  hoursInput.value = 7;
+  minutesInput.value = 0;
 }
 
 function calcEndTime() {


### PR DESCRIPTION
## Summary
- style radial-progress as a fullscreen pie chart background
- move progress element outside main container
- default duration hours to 7 and minutes to 0

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840627f20b88330972ab11b77d93efd